### PR TITLE
Add ServerBuddy to Minecraft server lists

### DIFF
--- a/notes/culture/game/minecraft/minecraft-awesome.md
+++ b/notes/culture/game/minecraft/minecraft-awesome.md
@@ -50,6 +50,8 @@ tags:
     - AGPLv3, Go
     - Reverse Proxy for Minecraft
 - Server List
+  - [ServerBuddy](https://serverbuddy.net/)
+    - Java and Bedrock server discovery with live status, player history, uptime, MOTD, and version history
   - https://minecraftservers.org/
   - https://play.mcmod.cn/
 - Client / Launcher


### PR DESCRIPTION
## Summary

- Add ServerBuddy to the Minecraft Server List resources.
- Note its Java and Bedrock coverage and the public telemetry available on server profiles.

## Verification

- `git diff --check`
- Confirmed `https://serverbuddy.net/` returns HTTP 200.
- Rendered the entry with GitHub's Markdown API.

## Disclosure

Submitted on behalf of ServerBuddy. The directory is free to use and has no voting mechanic or paid placement.
